### PR TITLE
Implement refreshMcpPackage function and update related tests

### DIFF
--- a/test/integration/suite/ui.test.js
+++ b/test/integration/suite/ui.test.js
@@ -15,22 +15,7 @@ suite('UI Integration', function () {
         assert.isTrue(extension.isActive, 'Extension should be active');
 
         const commands = await vscode.commands.getCommands(true);
-        assert.include(commands, 'stata-workbench.showInteractive');
         assert.include(commands, 'stata-workbench.runSelection');
         assert.include(commands, 'stata-workbench.runFile');
-    });
-
-    test('showInteractive should open the Interactive Panel', async () => {
-        // Trigger the command
-        await vscode.commands.executeCommand('stata-workbench.showInteractive');
-
-        // Wait a bit for the panel to be created
-        await new Promise(r => setTimeout(r, 1000));
-
-        // Use VS Code API to check for the panel tab
-        const tabs = vscode.window.tabGroups.all.flatMap(group => group.tabs);
-        const stataTab = tabs.find(tab => tab.label === 'Stata Interactive');
-
-        assert.ok(stataTab, 'Stata Interactive tab should be found');
     });
 });

--- a/test/unit/extension.test.js
+++ b/test/unit/extension.test.js
@@ -1,0 +1,82 @@
+const { assert } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+describe('extension refreshMcpPackage', () => {
+    let spawnSync;
+    let extension;
+
+    beforeEach(() => {
+        spawnSync = sinon.stub();
+
+        extension = proxyquire.noCallThru().load('../../src/extension', {
+            vscode: buildVscodeMock(),
+            './mcp-client': { client: { setLogger: () => { }, onStatusChanged: () => ({ dispose() { } }) } },
+            './interactive-panel': { InteractivePanel: { setExtensionUri: () => { }, addEntry: () => { }, show: () => { } } },
+            './artifact-utils': { openArtifact: () => { } },
+            fs: {
+                mkdirSync: sinon.stub(),
+                writeFileSync: sinon.stub(),
+                existsSync: sinon.stub().returns(false),
+                readFileSync: sinon.stub().returns('{}')
+            },
+            child_process: { spawnSync }
+        });
+    });
+
+    it('refreshes to latest version when uvx succeeds', () => {
+        spawnSync.returns({ status: 0, stdout: '2.0.0\n', stderr: '' });
+
+        const version = extension.refreshMcpPackage();
+
+        assert.equal(version, '2.0.0');
+        assert.isTrue(spawnSync.calledOnce, 'spawnSync should be invoked');
+        const [cmd, args] = spawnSync.firstCall.args;
+        assert.equal(cmd, 'uvx');
+        assert.includeMembers(args, ['--refresh', '--from', 'mcp-stata@latest', 'mcp-stata', '--version']);
+    });
+
+    it('returns null when uvx fails', () => {
+        spawnSync.returns({ status: 1, stdout: '', stderr: 'boom' });
+
+        const version = extension.refreshMcpPackage();
+
+        assert.isNull(version);
+        assert.isTrue(spawnSync.calledOnce, 'spawnSync should be invoked');
+    });
+});
+
+function buildVscodeMock() {
+    const noop = () => { };
+    const stubbedOutput = { appendLine: sinon.stub(), show: sinon.stub(), clear: sinon.stub() };
+    const stubbedStatus = { show: sinon.stub(), hide: sinon.stub(), dispose: sinon.stub() };
+
+    return {
+        window: {
+            createOutputChannel: () => stubbedOutput,
+            createStatusBarItem: () => stubbedStatus,
+            showErrorMessage: sinon.stub().resolves(),
+            showInformationMessage: sinon.stub().resolves()
+        },
+        StatusBarAlignment: { Right: 1 },
+        ProgressLocation: { Notification: 1 },
+        ThemeColor: function () { },
+        commands: {
+            registerCommand: sinon.stub(),
+            getCommands: sinon.stub().resolves([]),
+            executeCommand: sinon.stub().resolves()
+        },
+        workspace: {
+            workspaceFolders: [],
+            getConfiguration: sinon.stub().returns({ get: sinon.stub().returns('') })
+        },
+        env: {
+            clipboard: { writeText: sinon.stub().resolves() },
+            openExternal: sinon.stub()
+        },
+        Uri: {
+            parse: sinon.stub().returns({}),
+            joinPath: sinon.stub().returns({ fsPath: '' })
+        }
+    };
+}


### PR DESCRIPTION
This pull request introduces a new function to proactively refresh the `mcp-stata` package to its latest version and includes supporting tests for this functionality. It also makes minor adjustments to the integration tests for command registration.

**Enhancements to package management:**

* Added a `refreshMcpPackage` function in `src/extension.js` that attempts to update `mcp-stata` to the latest version using `uvx --refresh` before retrieving its version, improving reliability of version management.
* Modified the activation flow in `src/extension.js` to call `refreshMcpPackage` before falling back to the previous version retrieval logic, ensuring the extension uses the most up-to-date package.
* Exported the new `refreshMcpPackage` function for use in other modules and tests.

**Testing improvements:**

* Added a new unit test suite `test/unit/extension.test.js` to verify the behavior of `refreshMcpPackage`, including success and failure scenarios using stubs for process spawning.
* Updated the UI integration test in `test/integration/suite/ui.test.js` to remove the assertion and test for the `showInteractive` command, likely due to changes in command registration or panel behavior.