### PR TITLE
Updated for mcp-stata 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Updated graph export to use file paths by default (more token-efficient)
+- Added support for `max_output_lines` parameter to limit verbose output
+
+### Added
+- Configuration option: `stataMcp.maxOutputLines`
+- Configuration option: `stataMcp.useBase64Graphs`
+
 ## [0.3.1] - 2025-12-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -73,13 +73,15 @@ Offline/VSIX fallback:
 - **Test MCP Server** (`stata-workbench.testMcpServer`) for quick smoke checks.
 - **Install MCP CLI helper** (`stata-workbench.installMcpCli`): Bootstraps uv locally when it is missing.
 - **Status bar + cancel** (`stata-workbench.cancelRequest`): Live request states with one-click cancellation routed through the MCP client.
-- **Auto-manage MCP configs**: Writes the user-level `mcp.json` in your editor's user data so AI agents reuse the same `uvx --from mcp-stata --refresh mcp-stata` wiring, and auto-corrects older entries missing `--refresh`.
+- **Auto-manage MCP configs**: Writes the user-level `mcp.json` in your editor's user data so AI agents reuse the same `uvx --from mcp-stata@latest --refresh mcp-stata` wiring, and auto-corrects older entries missing `--refresh`.
 - **Durable logs**: All run results are logged to the `Stata Workbench` output channel for reference.
 
 ## Settings
 - `stataMcp.requestTimeoutMs` (default `45000`): timeout for MCP requests.
 - `stataMcp.autoRevealOutput` (default `true`): automatically show the output channel after runs.
 - `stataMcp.runFileWorkingDirectory` (default empty): working directory when running .do files. Supports an absolute path, ~, ${workspaceFolder} or ${fileDir}; empty uses the .do file's folder.
+- `stataMcp.maxOutputLines` (default `0`): limit Stata output to N lines (0 = unlimited). Useful for reducing token usage with AI agents.
+- `stataMcp.useBase64Graphs` (default `false`): if true, export graphs as base64 strings; otherwise use file paths. NOT RECOMMENDED: Base64 consumes many more tokens but may be more robust in some remote environments.
 
 ## Agent MCP configs (optional)
 When uv is available, the extension writes a user-level `mcp.json` inside your editor's user data. Example locations:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://github.com/tmonk/stata-workbench/issues"
   },
-  "version": "0.4.3",
+  "version": "0.4.4",
   "engines": {
     "vscode": "^1.75.0"
   },
@@ -142,6 +142,16 @@
           "type": "number",
           "default": 60,
           "description": "Timeout (seconds) for Stata initialization (stata_setup.config preflight). Passed to STATA_SETUP_TIMEOUT for mcp-stata."
+        },
+        "stataMcp.maxOutputLines": {
+          "type": "number",
+          "default": 0,
+          "description": "Maximum lines of output to return from Stata commands (0 = unlimited). Useful for limiting token usage with verbose commands like regress or codebook."
+        },
+        "stataMcp.useBase64Graphs": {
+          "type": "boolean",
+          "default": false,
+          "description": "Export graphs as base64-encoded data instead of file paths. Base64 is more token-intensive but works better for some workflows."
         }
       }
     },


### PR DESCRIPTION
This pull request introduces new configuration options to control Stata output verbosity and graph export format, and updates the extension to use these options for improved efficiency and flexibility. The changes also include a version bump and minor documentation updates.

**Configuration and Output Controls:**

* Added a new configuration option `stataMcp.maxOutputLines` to limit the number of output lines returned from Stata commands, helping reduce token usage for verbose commands. This option is now respected in all relevant client methods (`runSelection`, `run_file`, `run`). [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R145-R154) [[2]](diffhunk://#diff-e71152c5018f6af1f1cbd8849d4981313d04f3ad0de40e0c65573e85c3da9c9fR53-R62) [[3]](diffhunk://#diff-e71152c5018f6af1f1cbd8849d4981313d04f3ad0de40e0c65573e85c3da9c9fR71-R100)
* Added a new configuration option `stataMcp.useBase64Graphs` to export graphs as base64-encoded data instead of file paths. The graph export logic now uses this setting, defaulting to file paths for better token efficiency. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R145-R154) [[2]](diffhunk://#diff-e71152c5018f6af1f1cbd8849d4981313d04f3ad0de40e0c65573e85c3da9c9fR596-R605)

**Documentation Updates:**

* Updated `README.md` and `CHANGELOG.md` to document the new configuration options and clarify the default graph export behavior. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R84) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR6-R15)

**Other Improvements:**

* Changed the default MCP config wiring in the documentation to use `uvx --from mcp-stata@latest --refresh mcp-stata` for more robust agent reuse.
* Improved graph object parsing to prefer the `file_path` property when resolving graph links.
* Bumped extension version to `0.4.4` in `package.json`.