### PR TITLE
docs: Update Windsurf MCP config paths and add Windsurf Next support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Offline/VSIX fallback:
 <p align="center">
   <img src="img/screenshot.png" width="70%" alt="Stata Terminal panel showing Stata output cards and a graph artifact" />
   <br />
-  <em>Stata Terminal panel showing output cards and a graph artifact (click to enlarge).</em>
+  <em>Stata Terminal panel showing output cards and a graph artifact.</em>
 </p>
 
 <p align="center">
@@ -111,7 +111,8 @@ Stata Workbench **automatically writes** your MCP configuration when you first r
 | **VS Code** | `~/Library/Application Support/Code/User/mcp.json` | `%APPDATA%/Code/User/mcp.json` | `~/.config/Code/User/mcp.json` |
 | **VS Code Insiders** | `~/Library/Application Support/Code - Insiders/User/mcp.json` | `%APPDATA%/Code - Insiders/User/mcp.json` | `~/.config/Code - Insiders/User/mcp.json` |
 | **Cursor** | `~/.cursor/mcp.json` | `%USERPROFILE%/.cursor/mcp.json` | `~/.cursor/mcp.json` |
-| **Windsurf** | `~/.codeium/mcp_config.json` | `%USERPROFILE%/.codeium/mcp_config.json` | `~/.codeium/mcp_config.json` |
+| **Windsurf** | `~/.codeium/windsurf/mcp_config.json` | `%USERPROFILE%/.codeium/windsurf/mcp_config.json` | `~/.codeium/windsurf/mcp_config.json` |
+| **Windsurf Next** | `~/.codeium/windsurf-next/mcp_config.json` | `%USERPROFILE%/.codeium/windsurf-next/mcp_config.json` | `~/.codeium/windsurf-next/mcp_config.json` |
 | **Antigravity** | `~/Library/Application Support/Antigravity/User/mcp.json` | `%APPDATA%/Antigravity/User/mcp.json` | `~/.antigravity/mcp.json` |
 
 If you want to manage the file yourself, here is the content to add. User-level `mcp.json`:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bugs": {
     "url": "https://github.com/tmonk/stata-workbench/issues"
   },
-  "version": "0.8.0",
+  "version": "0.8.1",
   "engines": {
     "vscode": "^1.75.0"
   },

--- a/src/extension.js
+++ b/src/extension.js
@@ -343,7 +343,9 @@ function resolveHostMcpPath(appName, home, overridePath, platform, _hasHomeOverr
     }
 
     if (appName.includes('windsurf')) {
-        return { configPath: path.join(home, '.codeium', 'mcp_config.json'), prefersCursorFormat: true };
+        const isNext = appName.includes('next');
+        const dirName = isNext ? 'windsurf-next' : 'windsurf';
+        return { configPath: path.join(home, '.codeium', dirName, 'mcp_config.json'), prefersCursorFormat: true };
     }
 
     if (appName.includes('antigravity')) {

--- a/src/mcp-client.js
+++ b/src/mcp-client.js
@@ -1367,7 +1367,9 @@ class StataMcpClient {
         }
 
         if (appName.includes('windsurf')) {
-            return home ? path.join(home, '.codeium', 'mcp_config.json') : null;
+            const isNext = appName.includes('next');
+            const dirName = isNext ? 'windsurf-next' : 'windsurf';
+            return home ? path.join(home, '.codeium', dirName, 'mcp_config.json') : null;
         }
 
         if (appName.includes('antigravity')) {

--- a/test/unit/extension.test.js
+++ b/test/unit/extension.test.js
@@ -443,7 +443,34 @@ describe('extension refreshMcpPackage', () => {
             };
 
             const target = extWithFs.getMcpConfigTarget(ctx);
-            const expected = path.join('/home/alex', '.codeium', 'mcp_config.json');
+            const expected = path.join('/home/alex', '.codeium', 'windsurf', 'mcp_config.json');
+            assert.equal(target.configPath, expected);
+            assert.isTrue(target.writeCursor);
+        });
+
+        it('resolves Windsurf Next path on mac', () => {
+            const extWithFs = proxyquire.noCallThru().load('../../src/extension', {
+                vscode: buildVscodeMock(),
+                './mcp-client': { client: { setLogger: () => { }, onStatusChanged: () => ({ dispose() { } }) } },
+                            './terminal-panel': { TerminalPanel: { setExtensionUri: () => { }, addEntry: () => { }, show: () => { } } },
+                            './data-browser-panel': { DataBrowserPanel: { createOrShow: () => { } } },
+                            './artifact-utils': { openArtifact: () => { } },                fs: {
+                    mkdirSync: sinon.stub(),
+                    writeFileSync: sinon.stub(),
+                    existsSync: sinon.stub().returns(false),
+                    readFileSync: sinon.stub().returns('{}')
+                },
+                child_process: { spawnSync: sinon.stub() }
+            });
+
+            const ctx = {
+                mcpPlatformOverride: 'darwin',
+                mcpHomeOverride: '/Users/tom',
+                mcpAppNameOverride: 'Windsurf Next'
+            };
+
+            const target = extWithFs.getMcpConfigTarget(ctx);
+            const expected = path.join('/Users/tom', '.codeium', 'windsurf-next', 'mcp_config.json');
             assert.equal(target.configPath, expected);
             assert.isTrue(target.writeCursor);
         });


### PR DESCRIPTION
This pull request updates the handling of MCP configuration paths for the Windsurf and Windsurf Next applications, ensuring that configuration files are stored in app-specific directories. It also updates the documentation and adds tests for the new logic. The version is incremented to reflect these changes.

**MCP Configuration Path Updates:**

* Updated `resolveHostMcpPath` in `src/extension.js` to store Windsurf config at `.codeium/windsurf/mcp_config.json` and Windsurf Next at `.codeium/windsurf-next/mcp_config.json` instead of the previous shared location.
* Updated `StataMcpClient` in `src/mcp-client.js` to match the new directory structure for Windsurf and Windsurf Next config paths.

**Documentation:**

* Updated the `README.md` to document the new config file locations for Windsurf and add Windsurf Next, clarifying the directory structure.

**Testing:**

* Added and updated unit tests in `test/unit/extension.test.js` to verify correct resolution of config paths for both Windsurf and Windsurf Next.

**Other:**

* Incremented the package version in `package.json` from `0.8.0` to `0.8.1`.
* Minor edit to screenshot caption in `README.md` for clarity.