### PR TITLE
feat: Implement log fetching and filtering in terminal panel, enhance…

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -86,6 +86,7 @@ function activate(context) {
     context.subscriptions.push(...subscriptions, statusBarItem, outputChannel);
     globalExtensionUri = context.extensionUri;
     TerminalPanel.setExtensionUri(context.extensionUri);
+    TerminalPanel.setLogProvider((path, offset, maxBytes) => mcpClient.readLog(path, offset, maxBytes));
     missingCli = !ensureMcpCliAvailable(context);
     if (!missingCli) {
         const autoConfigureMcp = settings.get('autoConfigureMcp', true);

--- a/src/ui-shared/design.css
+++ b/src/ui-shared/design.css
@@ -892,3 +892,9 @@ textarea#command-input:focus {
     display: none;
   }
 }
+
+.scrollable-log {
+  max-height: 600px;
+  overflow-y: auto;
+  border-bottom: 1px solid var(--border-subtle);
+}

--- a/test/integration/suite/integration.test.js
+++ b/test/integration/suite/integration.test.js
@@ -33,7 +33,7 @@ describe('McpClient integration (VS Code host)', () => {
         fs.mkdirSync(doDir, { recursive: true });
         doFile = path.join(doDir, 'integration.do');
         fs.writeFileSync(doFile, [
-            'capture log close _all',
+            'capture log close',
             'log using "integration.log", replace text',
             'display "integration-ok"',
             'log close'

--- a/test/integration/suite/log-buffering.test.js
+++ b/test/integration/suite/log-buffering.test.js
@@ -1,0 +1,86 @@
+const assert = require('assert');
+const vscode = require('vscode');
+const path = require('path');
+const fs = require('fs');
+const { TerminalPanel } = require('../../../src/terminal-panel');
+
+describe('Log Buffering Integration', () => {
+
+    test('Backend calculates and sends logSize correctly', async () => {
+        // Setup: Create a temp log file
+        const logPath = path.join(__dirname, 'test.log');
+        const logContent = 'Line 1\nLine 2\nLine 3\n';
+        fs.writeFileSync(logPath, logContent);
+        const expectedSize = Buffer.byteLength(logContent, 'utf8');
+
+        // Spy on TerminalPanel._postMessage
+        // Since _postMessage is static, we can replace it for the test
+        const originalPostMessage = TerminalPanel._postMessage;
+        let capturedMessage = null;
+        TerminalPanel._postMessage = (msg) => {
+            if (msg.type === 'runFinished') {
+                capturedMessage = msg;
+            }
+        };
+
+        // Mock TerminalPanel.currentPanel to ensure guards pass
+        TerminalPanel.currentPanel = {
+            webview: { postMessage: () => { } }
+        };
+
+        try {
+            // Trigger finishStreamingEntry
+            const result = {
+                rc: 0,
+                logPath: logPath,
+                stdout: 'done',
+                stderr: '',
+                contentType: 'text'
+            };
+
+            TerminalPanel.finishStreamingEntry('test-run-1', result);
+
+            // Verify
+            assert.ok(capturedMessage, 'Should have sent runFinished message');
+            assert.strictEqual(capturedMessage.logPath, logPath, 'Log path should match');
+            assert.strictEqual(capturedMessage.logSize, expectedSize, `Log size should be ${expectedSize}, got ${capturedMessage.logSize}`);
+
+        } finally {
+            // Cleanup
+            TerminalPanel._postMessage = originalPostMessage;
+            if (fs.existsSync(logPath)) {
+                fs.unlinkSync(logPath);
+            }
+            TerminalPanel.currentPanel = undefined;
+        }
+    });
+
+    test('Backend handles missing log file gracefully', async () => {
+        const logPath = path.join(__dirname, 'nonexistent.log');
+
+        const originalPostMessage = TerminalPanel._postMessage;
+        let capturedMessage = null;
+        TerminalPanel._postMessage = (msg) => {
+            if (msg.type === 'runFinished') {
+                capturedMessage = msg;
+            }
+        };
+        TerminalPanel.currentPanel = { webview: { postMessage: () => { } } };
+
+        try {
+            const result = {
+                rc: 0,
+                logPath: logPath // Points to non-existent file
+            };
+
+            TerminalPanel.finishStreamingEntry('test-run-2', result);
+
+            assert.ok(capturedMessage);
+            assert.strictEqual(capturedMessage.logSize, 0, 'Log size should be 0 for missing file');
+
+        } finally {
+            TerminalPanel._postMessage = originalPostMessage;
+            TerminalPanel.currentPanel = undefined;
+        }
+    });
+});

--- a/test/integration/suite/scroll.test.js
+++ b/test/integration/suite/scroll.test.js
@@ -1,0 +1,110 @@
+const assert = require('assert');
+const vscode = require('vscode');
+const path = require('path');
+const fs = require('fs');
+const { TerminalPanel } = require('../../../src/terminal-panel');
+
+describe('Log Scrolling Integration', () => {
+    const logPath = path.join(__dirname, 'scroll_test.log');
+    // Create a log file larger than the default chunk size (assumed 100KB for the test, 
+    // but in the backend it respects the requested maxBytes).
+    // We will use 50 bytes chunks for testing to be granular.
+    const runId = 'test-scroll-run';
+    let cleanup = [];
+
+    beforeAll(() => {
+        // Generate a recognizable log file
+        // Lines "Line 000" to "Line 999"
+        let content = '';
+        for (let i = 0; i < 1000; i++) {
+            content += `Line ${String(i).padStart(3, '0')}\n`; // 9 bytes per line
+        }
+        // Total ~9000 bytes
+        fs.writeFileSync(logPath, content);
+    });
+
+    afterAll(() => {
+        if (fs.existsSync(logPath)) fs.unlinkSync(logPath);
+        cleanup.forEach(f => f());
+    });
+
+    test('Backend serves correct chunks for scrolling', async () => {
+        // We will directly invoke _handleFetchLog on a TerminalPanel instance
+        // But _handleFetchLog is an instance method. We need an instance.
+        // We can't easily start the real panel, but we can prototype-call it if it doesn't use `this` heavily
+        // OR we can rely on the fact that TerminalPanel is a class.
+
+        // Actually, _handleFetchLog is likely an instance method that calls this._postMessage
+        // We need to spy on `TerminalPanel._postMessage` (static) because that's how it replies.
+
+        const originalPostMessage = TerminalPanel._postMessage;
+        const messages = [];
+        TerminalPanel._postMessage = (msg) => {
+            messages.push(msg);
+        };
+        cleanup.push(() => TerminalPanel._postMessage = originalPostMessage);
+
+        // Setup log provider
+        TerminalPanel.setLogProvider(async (p, off, max) => {
+            // Basic file read simulation
+            if (!fs.existsSync(p)) return null;
+            const buf = fs.readFileSync(p);
+            const end = Math.min(buf.length, off + max);
+            const chunk = buf.slice(off, end);
+            return {
+                data: chunk.toString('utf8'),
+                next_offset: end
+            };
+        });
+        // Cleanup log provider? It's static, so good practice to clear it or restore original if we knew it.
+        // For now, just setting it is fine as we only run this test suite in isolation mostly, 
+        // but to be safe:
+        cleanup.push(() => TerminalPanel.setLogProvider(null));
+
+        // _handleFetchLog is static.
+        // It accepts (runId, path, offset, maxBytes)
+
+        /* 
+           src/terminal-panel.js:
+           async _handleFetchLog(message) {
+               ...
+               const data = ...
+               TerminalPanel._postMessage({ type: 'logChunk', ... });
+           }
+        */
+
+        // Test 1: Fetch the tail (simulate initial load)
+        // Total size ~9000 bytes. Request last 100 bytes.
+        const stats = fs.statSync(logPath);
+        const totalSize = stats.size;
+        const tailSize = 100;
+        const tailOffset = totalSize - tailSize;
+
+        await TerminalPanel._handleFetchLog(runId, logPath, tailOffset, tailSize);
+
+        const tailMsg = messages.find(m => m.offset === tailOffset);
+        assert.ok(tailMsg, 'Should send logChunk for tail');
+        assert.strictEqual(tailMsg.type, 'logChunk');
+        // Check content: Should contain "Line 999"
+        assert.ok(tailMsg.data.includes('Line 999'), 'Tail should contain last lines');
+
+        // Test 2: Fetch "scrolling up" (previous chunk)
+        messages.length = 0; // Clear
+        const prevOffset = tailOffset - 100; // Previous 100 bytes
+        await TerminalPanel._handleFetchLog(runId, logPath, prevOffset, 100);
+
+        const scrollMsg = messages.find(m => m.offset === prevOffset);
+        assert.ok(scrollMsg, 'Should send logChunk for scrolled section');
+        // Check content: Should be earlier in the file
+        // "Line 999" is at byte ~8991. 
+        // We are at 8900-9000.
+        // Previous is 8800-8900. Should contain something like "Line 98"
+        assert.ok(scrollMsg.data.includes('Line'), 'Should contain lines');
+        assert.ok(!scrollMsg.data.includes('Line 999'), 'Should NOT contain the very last line (it is previous chunk)');
+
+        // Ensure data is what we expect
+        const buffer = fs.readFileSync(logPath);
+        const expectedChunk = buffer.slice(prevOffset, prevOffset + 100).toString('utf8');
+        assert.strictEqual(scrollMsg.data, expectedChunk, 'Chunk content should match file content exactly');
+    });
+});

--- a/test/unit/extension.test.js
+++ b/test/unit/extension.test.js
@@ -35,7 +35,7 @@ describe('extension unit tests', () => {
             client: mcpClientMock
         }));
         jest.doMock('../../src/terminal-panel', () => ({
-            TerminalPanel: { setExtensionUri: jest.fn(), addEntry: jest.fn(), show: jest.fn() }
+            TerminalPanel: { setExtensionUri: jest.fn(), addEntry: jest.fn(), show: jest.fn(), setLogProvider: jest.fn() }
         }));
         jest.doMock('../../src/data-browser-panel', () => ({
             DataBrowserPanel: { createOrShow: jest.fn() }


### PR DESCRIPTION
… log display with a new LogViewer component

- Added a log provider to the TerminalPanel for fetching log data.
- Introduced a LogViewer class to handle log chunk display and scrolling.
- Filtered log output to exclude internal commands and metadata.
- Updated UI to support log viewing with a scrollable container.
- Adjusted integration tests to reflect changes in log handling.
- 
This pull request implements a major improvement to how Stata MCP logs are handled and viewed in the extension. Instead of loading the entire log file into memory, logs are now streamed on-demand from disk, enabling efficient viewing of large logs with infinite scroll behavior. The backend filters out internal metadata and commands from logs, and the frontend introduces a new `LogViewer` component for chunked, scrollable log display. This makes log viewing more performant and user-friendly, especially for large outputs.

**Backend log streaming and filtering:**

* Added a `_filterLogChunk` method to `StataMcpClient` to remove internal log commands and metadata from log output before displaying to the user. [[1]](diffhunk://#diff-e71152c5018f6af1f1cbd8849d4981313d04f3ad0de40e0c65573e85c3da9c9fR116-R137) [[2]](diffhunk://#diff-e71152c5018f6af1f1cbd8849d4981313d04f3ad0de40e0c65573e85c3da9c9fL489-R515) [[3]](diffhunk://#diff-e71152c5018f6af1f1cbd8849d4981313d04f3ad0de40e0c65573e85c3da9c9fL654-R685) [[4]](diffhunk://#diff-e71152c5018f6af1f1cbd8849d4981313d04f3ad0de40e0c65573e85c3da9c9fL688-R720)
* Implemented a new `readLog` method in `StataMcpClient` for reading log file slices from disk, used by the frontend to fetch log chunks on demand.
* Connected the backend log reading capability to the frontend via `TerminalPanel.setLogProvider` and a new message type (`fetchLog`). [[1]](diffhunk://#diff-41610ea8b06474549c4f312fdc247353665bc6434811db5418853bf57137bba5R89) [[2]](diffhunk://#diff-a2ca0b54897206e049e5d49312ddbb2c0bd90ee31162cee0c13ad0bb03ac797aR573-R575) [[3]](diffhunk://#diff-a2ca0b54897206e049e5d49312ddbb2c0bd90ee31162cee0c13ad0bb03ac797aL844-R901)

**Frontend log viewer and UI changes:**

* Added the `LogViewer` class to the frontend, which enables infinite scroll log viewing by fetching and rendering log chunks as the user scrolls.
* Updated the UI to display a log link, show log size, and use the new log viewer in both the result pane (on success) and the log tab (on failure), replacing the previous approach of loading the entire log into memory. [[1]](diffhunk://#diff-a2ca0b54897206e049e5d49312ddbb2c0bd90ee31162cee0c13ad0bb03ac797aR1594) [[2]](diffhunk://#diff-a2ca0b54897206e049e5d49312ddbb2c0bd90ee31162cee0c13ad0bb03ac797aR1638) [[3]](diffhunk://#diff-a2ca0b54897206e049e5d49312ddbb2c0bd90ee31162cee0c13ad0bb03ac797aR1701) [[4]](diffhunk://#diff-a2ca0b54897206e049e5d49312ddbb2c0bd90ee31162cee0c13ad0bb03ac797aL1661-R1713) [[5]](diffhunk://#diff-a2ca0b54897206e049e5d49312ddbb2c0bd90ee31162cee0c13ad0bb03ac797aL1972-R2078) [[6]](diffhunk://#diff-a2ca0b54897206e049e5d49312ddbb2c0bd90ee31162cee0c13ad0bb03ac797aL1994-R2123)
* Ensured that log fetching applies SMCL formatting to each chunk for consistent display in the webview.

These changes make log handling much more scalable and responsive, particularly when working with large Stata log files.