### PR TITLE
feat: Allow running dirty do files

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,15 @@
           "default": 0,
           "description": "Maximum lines of output to return from Stata commands (0 = unlimited). Useful for limiting token usage with verbose commands like regress or codebook."
         },
+        "stataMcp.runFileBehavior": {
+          "type": "string",
+          "enum": [
+            "runDirtyFile",
+            "runDiskFile"
+          ],
+          "default": "runDirtyFile",
+          "description": "Choose whether 'Run File' should run the current editor content (including unsaved changes) or the version saved on disk."
+        },
         "stataMcp.useBase64Graphs": {
           "type": "boolean",
           "default": false,

--- a/src/mcp-client.js
+++ b/src/mcp-client.js
@@ -138,7 +138,8 @@ class StataMcpClient {
     async runFile(filePath, options = {}) {
         const { normalizeResult, includeGraphs, onLog, onProgress, cancellationToken: externalCancellationToken, ...rest } = options || {};
         // Resolve working directory (configurable, defaults to the .do file folder).
-        const cwd = this._resolveRunFileCwd(filePath);
+        // Allow caller to override CWD (important for running temp files while preserving original CWD).
+        const cwd = (rest && typeof rest.cwd === 'string') ? rest.cwd : this._resolveRunFileCwd(filePath);
         const config = vscode.workspace.getConfiguration('stataMcp');
         const maxOutputLines = Number.isFinite(config.get('maxOutputLines', 0)) && config.get('maxOutputLines', 0) > 0
             ? config.get('maxOutputLines', 0)

--- a/test/integration/suite/index.js
+++ b/test/integration/suite/index.js
@@ -10,11 +10,16 @@ async function run() {
     global.realVscode = require('vscode');
     console.log('[INTEGRATION] MCP_STATA_INTEGRATION:', process.env.MCP_STATA_INTEGRATION);
 
+    // Use JEST_TEST_MATCH if provided, otherwise run most integration tests (excluding benchmarks by default unless requested)
+    const testMatch = process.env.JEST_TEST_MATCH
+        ? [process.env.JEST_TEST_MATCH]
+        : ['<rootDir>/test/integration/suite/*.test.js', '!**/benchmark.test.js'];
+
     try {
         const result = await runCLI(
             {
                 config: configPath,
-                testMatch: ['<rootDir>/test/integration/suite/benchmark.test.js'],
+                testMatch,
                 runInBand: true, // Required for VS Code integration tests
                 testEnvironment: 'node',
                 setupFilesAfterEnv: [],

--- a/test/integration/suite/run-dirty-file.test.js
+++ b/test/integration/suite/run-dirty-file.test.js
@@ -1,0 +1,150 @@
+const vscode = require('vscode');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+describe('Run Dirty File Integration', () => {
+    jest.setTimeout(60000);
+
+    const enabled = process.env.MCP_STATA_INTEGRATION === '1';
+
+    let testDir;
+    let diskFile;
+    let sideFile;
+
+    beforeAll(() => {
+        // Create a temporary directory for this test
+        testDir = path.join(os.tmpdir(), `stata_test_${Date.now()}`);
+        fs.mkdirSync(testDir, { recursive: true });
+
+        // The main file we will edit
+        diskFile = path.join(testDir, 'main.do');
+        fs.writeFileSync(diskFile, 'display "DISK-VERSION"');
+
+        // A side file to test CWD preservation
+        sideFile = path.join(testDir, 'side.do');
+        fs.writeFileSync(sideFile, 'display "SIDE-FILE-RUNS"');
+    });
+
+    afterAll(() => {
+        if (fs.existsSync(testDir)) {
+            try {
+                // Simplified recursive delete
+                const files = fs.readdirSync(testDir);
+                for (const file of files) {
+                    fs.unlinkSync(path.join(testDir, file));
+                }
+                fs.rmdirSync(testDir);
+            } catch (e) {
+                console.error('Cleanup failed:', e);
+            }
+        }
+    });
+
+    test('Run File should reflect unsaved changes while preserving CWD', async () => {
+        if (!enabled) {
+            return;
+        }
+
+        // Get extension API
+        const extension = vscode.extensions.getExtension('tmonk.stata-workbench');
+        expect(extension).toBeTruthy();
+        if (!extension.isActive) await extension.activate();
+        const api = extension.exports;
+
+        // Setup capture
+        const outgoing = [];
+        api.TerminalPanel._testOutgoingCapture = (msg) => outgoing.push(msg);
+
+        try {
+            // 1. Open the file
+            const doc = await vscode.workspace.openTextDocument(diskFile);
+            const editor = await vscode.window.showTextDocument(doc);
+
+            // 2. Modify the file (making it dirty)
+            // We'll add a line that runs the side file to verify CWD
+            const newContent = 'display "UNSAVED-VERSION"\ndo "side.do"';
+            await editor.edit(editBuilder => {
+                editBuilder.replace(new vscode.Range(0, 0, doc.lineCount, 0), newContent);
+            });
+            expect(doc.isDirty).toBe(true);
+
+            // 3. Run the file
+            await vscode.commands.executeCommand('stata-workbench.runFile');
+
+            // 4. Wait for completion
+            let runFinished = null;
+            for (let i = 0; i < 120; i++) {
+                runFinished = outgoing.find(m => m?.type === 'runFinished');
+                if (runFinished) break;
+                await new Promise(r => setTimeout(r, 500));
+            }
+
+            expect(runFinished).toBeTruthy();
+            expect(runFinished.success).toBe(true);
+
+            const stdout = String(runFinished.stdout || '');
+            // Verify unsaved content was run
+            expect(stdout).toContain('UNSAVED-VERSION');
+            expect(stdout).not.toContain('DISK-VERSION');
+
+            // Verify CWD was preserved (side.do was found and run)
+            expect(stdout).toContain('SIDE-FILE-RUNS');
+
+        } finally {
+            api.TerminalPanel._testOutgoingCapture = null;
+            // Close editors
+            await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+        }
+    });
+
+    test('Run File should honor runDiskFile behavior', async () => {
+        if (!enabled) {
+            return;
+        }
+
+        const extension = vscode.extensions.getExtension('tmonk.stata-workbench');
+        expect(extension).toBeTruthy();
+        if (!extension.isActive) await extension.activate();
+        const api = extension.exports;
+
+        const outgoing = [];
+        api.TerminalPanel._testOutgoingCapture = (msg) => outgoing.push(msg);
+
+        // Configure setting to run disk file
+        await vscode.workspace.getConfiguration('stataMcp').update('runFileBehavior', 'runDiskFile', vscode.ConfigurationTarget.Global);
+
+        try {
+            const doc = await vscode.workspace.openTextDocument(diskFile);
+            const editor = await vscode.window.showTextDocument(doc);
+
+            await editor.edit(editBuilder => {
+                editBuilder.replace(new vscode.Range(0, 0, doc.lineCount, 0), 'display "SHOULD-NOT-RUN"');
+            });
+            expect(doc.isDirty).toBe(true);
+
+            await vscode.commands.executeCommand('stata-workbench.runFile');
+
+            let runFinished = null;
+            for (let i = 0; i < 120; i++) {
+                runFinished = outgoing.find(m => m?.type === 'runFinished');
+                if (runFinished) break;
+                await new Promise(r => setTimeout(r, 500));
+            }
+
+            expect(runFinished).toBeTruthy();
+            expect(runFinished.success).toBe(true);
+
+            const stdout = String(runFinished.stdout || '');
+            // Verify disk content was run, NOT unsaved content
+            expect(stdout).toContain('DISK-VERSION');
+            expect(stdout).not.toContain('SHOULD-NOT-RUN');
+
+        } finally {
+            // Restore default setting
+            await vscode.workspace.getConfiguration('stataMcp').update('runFileBehavior', 'runDirtyFile', vscode.ConfigurationTarget.Global);
+            api.TerminalPanel._testOutgoingCapture = null;
+            await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+        }
+    });
+});

--- a/test/unit/mcp-client.test.js
+++ b/test/unit/mcp-client.test.js
@@ -357,6 +357,25 @@ describe('McpClient', () => {
             enqueueStub.restore();
             vscodeMock.workspace.workspaceFolders = originalFolders;
         });
+
+        it('should respect explicitly provided cwd in options', async () => {
+            const callToolStub = client._callTool;
+            callToolStub.resetBehavior();
+            callToolStub.callsFake(async (_client, name, args) => ({ name, args }));
+
+            const enqueueStub = sinon.stub(client, '_enqueue').callsFake(async (label, rest, task, meta, normalize, collect) => {
+                const taskResult = await task({});
+                return { label, rest, meta, normalize, collect, taskResult };
+            });
+
+            const explicitCwd = '/explicit/cwd';
+            const result = await client.runFile('/tmp/script.do', { cwd: explicitCwd });
+
+            expect(result.meta.cwd).toEqual(explicitCwd);
+            expect(result.taskResult.args.cwd).toEqual(explicitCwd);
+
+            enqueueStub.restore();
+        });
     });
 
     describe('cwd propagation', () => {


### PR DESCRIPTION
Add runFileBehavior configuration and enhance runFile functionality

- Introduced a new configuration option `runFileBehavior` to allow users to choose between running unsaved changes or the saved version of a file.
- Updated the `runFile` function to handle temporary files for unsaved changes when `runDirtyFile` is selected.
- Enhanced the `runFile` method in the MCP client to respect the provided working directory, improving the handling of temporary files.
- Added integration tests to verify the behavior of running dirty files and ensuring the correct file is executed based on user settings.

This pull request introduces a new configurable behavior for the "Run File" action in the Stata Workbench extension, allowing users to choose whether to run the current editor content (including unsaved changes) or the version saved on disk. It also ensures the correct working directory (CWD) is preserved when running unsaved files, adds robust integration and unit tests for the new behavior, and improves test configuration flexibility.

Key changes:

**New Feature: Run File Behavior Configuration**
* Added a new `stataMcp.runFileBehavior` setting in `package.json` to let users choose between running the unsaved editor content (`runDirtyFile`) or the saved disk file (`runDiskFile`) when executing "Run File".

**Implementation of Run File Behavior**
* Updated `runFile` in `src/extension.js` to check the new setting: if the file is dirty and `runDirtyFile` is selected, it creates a temporary file with unsaved changes and runs it; otherwise, it runs the file from disk. The original CWD is preserved for correct file resolution. Temporary files are cleaned up after execution. [[1]](diffhunk://#diff-41610ea8b06474549c4f312fdc247353665bc6434811db5418853bf57137bba5R652-R680) [[2]](diffhunk://#diff-41610ea8b06474549c4f312fdc247353665bc6434811db5418853bf57137bba5R703-R711)

**CWD Handling in Client**
* Modified `StataMcpClient.runFile` in `src/mcp-client.js` to allow the caller to override the working directory via options, which is necessary for running temporary files while maintaining the original file's directory context.

**Testing: Integration and Unit Tests**
* Added a comprehensive integration test (`test/integration/suite/run-dirty-file.test.js`) to verify both behaviors: running unsaved changes and running the disk file, including checks for CWD preservation and correct output.
* Added a unit test to ensure `runFile` respects an explicitly provided `cwd` option.

**Testing: Test Runner Flexibility**
* Updated the integration test runner to support a `JEST_TEST_MATCH` environment variable, allowing selective test execution and excluding benchmarks by default unless requested.