### PR TITLE
Bug fixes

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -1445,6 +1445,11 @@ function updateStatusBar(status) {
 }
 
 async function refreshDatasetSummary() {
+    // Only refresh if the user is actually using the extension UI
+    if (!TerminalPanel.currentPanel && !DataBrowserPanel.currentPanel) {
+        return;
+    }
+
     try {
         const channel = await mcpClient.getUiChannel();
         if (channel && channel.baseUrl && channel.token) {

--- a/src/ui-shared/autocomplete.js
+++ b/src/ui-shared/autocomplete.js
@@ -177,7 +177,7 @@
     function update() {
       if (applying) return;
       const vars = getVars();
-      if (!vars.length) { requestVars(); close(); return; }
+      if (!vars.length) { close(); return; }
       const token = currentToken(inputEl);
       if (!token || !token.prefix) { close(); return; }
       const matches = vars.filter(function (n) {

--- a/test/integration/suite/data-browser.test.js
+++ b/test/integration/suite/data-browser.test.js
@@ -8,6 +8,7 @@ describe('Data Browser Integration', () => {
     let dummyUrl;
 
     beforeEach(async () => {
+        jest.useFakeTimers();
         // Start a dummy HTTP server to act as the Stata API for proxy tests
         // This ensures the test is reliable even if Stata isn't running
         await new Promise(resolve => {

--- a/test/mocks/vscode.js
+++ b/test/mocks/vscode.js
@@ -11,6 +11,16 @@ const createVscodeMock = () => {
     };
 
     const vscode = {
+        extensions: {
+            getExtension: jest.fn().mockReturnValue({
+                isActive: true,
+                activate: jest.fn().mockResolvedValue({}),
+                exports: {
+                    DataBrowserPanel: { _performRequest: jest.fn() },
+                    mcpClient: { getUiChannel: jest.fn() }
+                }
+            })
+        },
         workspace: {
             _configListeners: [],
             getConfiguration: jest.fn().mockReturnValue(configuration),
@@ -59,9 +69,13 @@ const createVscodeMock = () => {
             withProgress: jest.fn().mockImplementation((_options, task) => task({ isCancellationRequested: false }))
         },
         commands: {
-            registerCommand: jest.fn(),
+            _commands: [],
+            registerCommand: jest.fn().mockImplementation((name) => {
+                vscode.commands._commands.push(name);
+                return { dispose: () => { vscode.commands._commands = vscode.commands._commands.filter(c => c !== name); } };
+            }),
             executeCommand: jest.fn().mockResolvedValue(),
-            getCommands: jest.fn().mockResolvedValue([])
+            getCommands: jest.fn().mockImplementation(async () => vscode.commands._commands)
         },
         Uri: {
             file: (path) => ({ fsPath: path, with: () => ({ toString: () => `file://${path}` }), path }),

--- a/test/unit/autocomplete.test.js
+++ b/test/unit/autocomplete.test.js
@@ -691,3 +691,46 @@ describe('Autocomplete – HTML structure', () => {
     expect(htmlContent).toMatch(/stataAutocomplete\.createController/);
   }));
 });
+
+describe('Autocomplete – Regression: Infinite Loop (Empty Variables)', () => {
+  it('does NOT trigger onRequestVariables when update() is called with 0 variables', () => {
+    const dom = new JSDOM('<!doctype html><html><body><textarea id="inp"></textarea><div id="dd"></div></body></html>');
+    let requestCount = 0;
+    
+    const ac = createController({
+      inputEl: dom.window.document.getElementById('inp'),
+      dropdownEl: dom.window.document.getElementById('dd'),
+      variables: [],
+      document: dom.window.document,
+      onRequestVariables: () => {
+        requestCount++;
+      }
+    });
+
+    // Call update manually (this is what was looping)
+    ac.update();
+
+    expect(requestCount).toBe(0);
+  });
+
+  it('DOES still trigger onRequestVariables when Tab is pressed with 0 variables', () => {
+    const dom = new JSDOM('<!doctype html><html><body><textarea id="inp"></textarea><div id="dd"></div></body></html>');
+    let requestCount = 0;
+    const inputEl = dom.window.document.getElementById('inp');
+    inputEl.value = 'a';
+    inputEl.selectionStart = 1;
+    
+    const ac = createController({
+      inputEl,
+      dropdownEl: dom.window.document.getElementById('dd'),
+      variables: [],
+      document: dom.window.document,
+      onRequestVariables: () => {
+        requestCount++;
+      }
+    });
+
+    ac.handleTab();
+    expect(requestCount).toBe(1);
+  });
+});

--- a/test/unit/repro_loop.test.js
+++ b/test/unit/repro_loop.test.js
@@ -1,0 +1,89 @@
+
+const fs = require('fs');
+const path = require('path');
+
+// Simulate the "broken" autocomplete.js content (pre-fix)
+const brokenAutocompleteCode = `
+(function () {
+  function createController(opts) {
+    function getVars() { return opts.variables || []; }
+    function requestVars() { if (opts.onRequestVariables) opts.onRequestVariables(); }
+    function close() {}
+    
+    function update() {
+      const vars = getVars();
+      // THE BUG: If vars is empty, it calls requestVars()
+      if (!vars.length) { 
+        requestVars(); 
+        close(); 
+        return; 
+      }
+    }
+    return { update: update };
+  }
+  return { createController: createController };
+})()
+`;
+
+// Simulate the "fixed" autocomplete.js content (post-fix)
+const fixedAutocompleteCode = `
+(function () {
+  function createController(opts) {
+    function getVars() { return opts.variables || []; }
+    function requestVars() { if (opts.onRequestVariables) opts.onRequestVariables(); }
+    function close() {}
+    
+    function update() {
+      const vars = getVars();
+      // THE FIX: If vars is empty, just close. Don't trigger a new request.
+      if (!vars.length) { 
+        close(); 
+        return; 
+      }
+    }
+    return { update: update };
+  }
+  return { createController: createController };
+})()
+`;
+
+function runTest(name, code) {
+    console.log(`\n--- Testing ${name} ---`);
+    let requestCount = 0;
+    const variables = [];
+    
+    // Load the code
+    const factory = eval(code);
+
+    // Mock for the controller options
+    const opts = {
+        variables: variables,
+        onRequestVariables: () => {
+            requestCount++;
+            console.log(`[Test] requestVariables called (Total: ${requestCount})`);
+            
+            // Simulate the extension responding with an empty list
+            // In a real webview, this happens asynchronously.
+            // We simulate the feedback loop by calling update() again.
+            if (requestCount < 5) {
+                console.log(`[Test] Simulating extension response with empty list -> calling update()...`);
+                // Use process.nextTick to simulate async behavior
+                process.nextTick(() => controller.update());
+            } else {
+                console.log(`[Test] Stopping simulation at 5 requests to avoid actual infinite loop in test.`);
+            }
+        }
+    };
+
+    const controller = factory.createController(opts);
+
+    // Initial trigger (e.g. from boot or first update)
+    console.log(`[Test] Triggering initial update...`);
+    controller.update();
+}
+
+runTest('BROKEN VERSION', brokenAutocompleteCode);
+
+setTimeout(() => {
+    runTest('FIXED VERSION', fixedAutocompleteCode);
+}, 500);


### PR DESCRIPTION
This pull request addresses a regression in the autocomplete feature, fixes a potential infinite loop, and improves test coverage and mocks. The most important changes are grouped below:

### Bug Fixes and Autocomplete Improvements

* Fixed an infinite loop in `autocomplete.js` by ensuring that `requestVars()` is not called when the variable list is empty during the `update()` function, preventing repeated requests when no variables are available.
* Added regression tests in `autocomplete.test.js` to verify that `onRequestVariables` is not triggered on empty variables during update, but is still triggered on Tab press.
* Added a standalone test (`repro_loop.test.js`) to simulate and demonstrate the infinite loop bug and its fix for future reference.

### Extension and Integration Test Improvements

* Updated `vscode` mock to better simulate extension activation, command registration, and command retrieval, improving test reliability. [[1]](diffhunk://#diff-c5a26027b1f17a51161c40b6ea98c53ea77bf117a535c0fa6da521dc4df477dcR14-R23) [[2]](diffhunk://#diff-c5a26027b1f17a51161c40b6ea98c53ea77bf117a535c0fa6da521dc4df477dcL62-R78)
* Added `jest.useFakeTimers()` to integration tests for more reliable timing and async handling.

### Other Updates

* Updated the `mcp-stata` submodule to a new commit.
* Improved performance by preventing unnecessary dataset summary refreshes when the extension UI is not in use.