### PR TITLE
feat!: Migrate MCP tool calls to unified 'stata_*' API

### DIFF
--- a/src/instrument.js
+++ b/src/instrument.js
@@ -48,7 +48,7 @@ Sentry.init({
                 url.includes("mcp-stata") ||
                 url.includes("tmonk") ||
                 url.includes("pypi.org/pypi/mcp-stata") ||
-                url.includes("localhost") && (url.includes("get_ui_channel") || url.includes("stata"));
+                url.includes("localhost") && (url.includes("get_ui_channel") || url.includes("stata_manage_session") || url.includes("stata"));
 
             if (!isOurs) return null;
         }

--- a/src/mcp-client.js
+++ b/src/mcp-client.js
@@ -62,7 +62,6 @@ class StataMcpClient {
         this._clientVersion = pkg?.version || 'dev';
         this._onTaskDone = null;
         this._availableTools = new Set();
-        this._toolMapping = new Map();
         this._missingRequiredTools = [];
         this._forceLatestServer = false;
         this._forceLatestAttempted = false;
@@ -345,25 +344,12 @@ class StataMcpClient {
 
     async fetchGraph(name, options = {}) {
         return this._enqueue('stata_manage_graphs', options, async (client) => {
-            // Respect requested format; default to server default (often SVG) unless format is provided.
             const preferredFormat = options.format || null;
             const baseArgs = { action: 'export', graph_name: name };
             const primaryArgs = preferredFormat ? { ...baseArgs, format: preferredFormat } : baseArgs;
 
             const primary = await this._callTool(client, 'stata_manage_graphs', primaryArgs);
-            let artifact = this._graphResponseToArtifact(primary, name, options.baseDir);
-
-            // If the server returned a non-PDF artifact (e.g., SVG) and we need PDF, try again forcing PDF.
-            const hasPdfPath = artifact?.path && /\.pdf$/i.test(artifact.path);
-            if (preferredFormat === 'pdf' && !hasPdfPath) {
-                const fallback = await this._callTool(client, 'stata_manage_graphs', { ...baseArgs, format: 'pdf' });
-                const fallbackArtifact = this._graphResponseToArtifact(fallback, name, options.baseDir);
-                if (fallbackArtifact && (fallbackArtifact.path && /\.pdf$/i.test(fallbackArtifact.path))) {
-                    artifact = fallbackArtifact;
-                }
-            }
-
-            return artifact;
+            return this._graphResponseToArtifact(primary, name, options.baseDir);
         });
     }
 
@@ -833,7 +819,6 @@ class StataMcpClient {
     async _refreshToolList(client) {
         if (!client || typeof client.listTools !== 'function') {
             this._availableTools = new Set();
-            this._toolMapping = new Map();
             return;
         }
 
@@ -842,22 +827,6 @@ class StataMcpClient {
             const tools = Array.isArray(res?.tools) ? res.tools : [];
             const names = tools.map(t => t?.name).filter(Boolean);
             this._availableTools = new Set(names);
-            this._toolMapping = new Map();
-
-            // Populate mapping for common tools
-            for (const fullName of names) {
-                // Handle prefixes like mcp_mcp_stata_run_command -> run_command
-                const shortName = fullName.split('_').filter(part => !['mcp', 'stata'].includes(part.toLowerCase())).join('_');
-                if (shortName && !this._toolMapping.has(shortName)) {
-                    this._toolMapping.set(shortName, fullName);
-                }
-                // Also handle direct suffix matches
-                const suffixMatch = ['stata_run', 'stata_inspect_data', 'stata_manage_graphs', 'stata_read_log', 'stata_manage_session', 'stata_task_status', 'stata_control', 'stata_load_data', 'stata_inspect_results', 'stata_get_help']
-                    .find(s => fullName.endsWith(s));
-                if (suffixMatch && !this._toolMapping.has(suffixMatch)) {
-                    this._toolMapping.set(suffixMatch, fullName);
-                }
-            }
 
             if (names.length) {
                 this._log(`[mcp-stata] available tools: ${names.join(', ')}`);
@@ -870,15 +839,12 @@ class StataMcpClient {
         } catch (err) {
             this._captureMcpError(err);
             this._availableTools = new Set();
-            this._toolMapping = new Map();
             const context = this._formatRecentStderr();
             this._log(`[mcp-stata] listTools failed: ${err?.message || err}${context}`);
         }
     }
 
     _resolveToolName(name) {
-        if (this._availableTools?.has(name)) return name;
-        if (this._toolMapping?.has(name)) return this._toolMapping.get(name);
         return name;
     }
 
@@ -2142,13 +2108,7 @@ class StataMcpClient {
 
 
     async _exportGraphPreferred(client, name) {
-        // Prefer PDF export for durable artifacts; fall back to default.
-        try {
-            return await this._callTool(client, 'stata_manage_graphs', { action: 'export', graph_name: name, format: 'pdf' });
-        } catch (err) {
-            this._log(`[mcp-stata] stata_manage_graphs (export:pdf) failed for "${name}", falling back to default format: ${err?.message || err}`);
-            return await this._callTool(client, 'stata_manage_graphs', { action: 'export', graph_name: name });
-        }
+        return await this._callTool(client, 'stata_manage_graphs', { action: 'export', graph_name: name, format: 'pdf' });
     }
 
     _firstGraphs(candidate) {

--- a/src/mcp-client.js
+++ b/src/mcp-client.js
@@ -133,7 +133,7 @@ class StataMcpClient {
 
         const cts = this._createCancellationSource(externalCancellationToken);
 
-        const result = await this._enqueue('run_selection', { ...rest, runId, cancellationToken: cts.token, cancellationSource: cts, deferArtifacts: true }, async (client) => {
+        const result = await this._enqueue('stata_run', { ...rest, runId, cancellationToken: cts.token, cancellationSource: cts, deferArtifacts: true }, async (client) => {
             const args = { code: selection };
             if (maxOutputLines && maxOutputLines > 0) {
                 args.max_output_lines = maxOutputLines;
@@ -158,7 +158,7 @@ class StataMcpClient {
             }
 
             const result = await this._withActiveRun(runState, async () => {
-                const kickoff = await this._callTool(client, 'run_command_background', args, { progressToken, signal: cts.abortController.signal });
+                const kickoff = await this._callTool(client, 'stata_run', { ...args, background: true }, { progressToken, signal: cts.abortController.signal });
                 return this._awaitBackgroundResult(client, runState, kickoff, cts);
             });
             if (!runState.logPath) {
@@ -198,12 +198,12 @@ class StataMcpClient {
 
         const cts = this._createCancellationSource(externalCancellationToken);
 
-        const result = await this._enqueue('run_file', { ...rest, runId, cancellationToken: cts.token, cancellationSource: cts, deferArtifacts: true }, async (client) => {
+        const result = await this._enqueue('stata_run', { ...rest, runId, cancellationToken: cts.token, cancellationSource: cts, deferArtifacts: true }, async (client) => {
             const args = {
-                // Use absolute path so the server can locate the file, but also
-                // pass cwd so any relative includes resolve.
+                code: filePath,
                 path: filePath,
-                cwd
+                is_file: true,
+                cwd: cwd && cwd.trim() ? cwd : undefined
             };
             if (maxOutputLines && maxOutputLines > 0) {
                 args.max_output_lines = maxOutputLines;
@@ -225,7 +225,7 @@ class StataMcpClient {
             }
 
             const result = await this._withActiveRun(runState, async () => {
-                const kickoff = await this._callTool(client, 'run_do_file_background', args, { progressToken, signal: cts.abortController.signal });
+                const kickoff = await this._callTool(client, 'stata_run', { ...args, background: true, is_file: true }, { progressToken, signal: cts.abortController.signal });
                 return this._awaitBackgroundResult(client, runState, kickoff, cts);
             });
             if (!runState.logPath) {
@@ -278,7 +278,7 @@ class StataMcpClient {
             }
 
             const result = await this._withActiveRun(runState, async () => {
-                const kickoff = await this._callTool(client, 'run_command_background', args, { progressToken, signal: cts.abortController.signal });
+                const kickoff = await this._callTool(client, 'stata_run', { ...args, background: true }, { progressToken, signal: cts.abortController.signal });
                 return this._awaitBackgroundResult(client, runState, kickoff, cts);
             });
             if (!runState.logPath) {
@@ -299,35 +299,35 @@ class StataMcpClient {
             return result;
         };
 
-        const result = await this._enqueue('run_command', { ...rest, cancellationToken: cts.token, cancellationSource: cts, deferArtifacts: true }, task, meta, true, true);
+        const result = await this._enqueue('stata_run', { ...rest, cancellationToken: cts.token, cancellationSource: cts, deferArtifacts: true }, task, meta, true, true);
         return result;
     }
 
     async viewData(start = 0, count = 50, options = {}) {
-        return this._enqueue('view_data', options, async (client) => {
-            const response = await this._callTool(client, 'get_data', { start, count });
+        return this._enqueue('stata_inspect_data', options, async (client) => {
+            const response = await this._callTool(client, 'stata_inspect_data', { action: 'get', start, count });
             return this._parseJson(response);
         });
     }
 
     async getUiChannel(options = {}) {
-        return this._enqueue('get_ui_channel', options, async (client) => {
-            const response = await this._callTool(client, 'get_ui_channel', {});
+        return this._enqueue('stata_manage_session', options, async (client) => {
+            const response = await this._callTool(client, 'stata_manage_session', { action: 'get_ui_channel' });
             const text = this._extractText(response);
             return this._tryParseJson(text) || this._parseJson(response);
         });
     }
 
     async getVariableList(options = {}) {
-        return this._enqueue('get_variable_list', options, async (client) => {
-            const response = await this._callTool(client, 'get_variable_list', {});
+        return this._enqueue('stata_inspect_data', options, async (client) => {
+            const response = await this._callTool(client, 'stata_inspect_data', { action: 'list' });
             return this._normalizeVariableList(response);
         });
     }
 
     async listGraphs(options = {}) {
-        return this._enqueue('list_graphs', options, async (client) => {
-            const raw = await this._callTool(client, 'list_graphs', {});
+        return this._enqueue('stata_manage_graphs', options, async (client) => {
+            const raw = await this._callTool(client, 'stata_manage_graphs', { action: 'list' });
             const artifacts = await this._resolveArtifactsFromList(raw, options?.baseDir, client);
             return { graphs: artifacts };
         });
@@ -344,19 +344,19 @@ class StataMcpClient {
     }
 
     async fetchGraph(name, options = {}) {
-        return this._enqueue('fetch_graph', options, async (client) => {
+        return this._enqueue('stata_manage_graphs', options, async (client) => {
             // Respect requested format; default to server default (often SVG) unless format is provided.
             const preferredFormat = options.format || null;
-            const baseArgs = { graph_name: name };
+            const baseArgs = { action: 'export', graph_name: name };
             const primaryArgs = preferredFormat ? { ...baseArgs, format: preferredFormat } : baseArgs;
 
-            const primary = await this._callTool(client, 'export_graph', primaryArgs);
+            const primary = await this._callTool(client, 'stata_manage_graphs', primaryArgs);
             let artifact = this._graphResponseToArtifact(primary, name, options.baseDir);
 
             // If the server returned a non-PDF artifact (e.g., SVG) and we need PDF, try again forcing PDF.
             const hasPdfPath = artifact?.path && /\.pdf$/i.test(artifact.path);
             if (preferredFormat === 'pdf' && !hasPdfPath) {
-                const fallback = await this._callTool(client, 'export_graph', { ...baseArgs, format: 'pdf' });
+                const fallback = await this._callTool(client, 'stata_manage_graphs', { ...baseArgs, format: 'pdf' });
                 const fallbackArtifact = this._graphResponseToArtifact(fallback, name, options.baseDir);
                 if (fallbackArtifact && (fallbackArtifact.path && /\.pdf$/i.test(fallbackArtifact.path))) {
                     artifact = fallbackArtifact;
@@ -852,7 +852,7 @@ class StataMcpClient {
                     this._toolMapping.set(shortName, fullName);
                 }
                 // Also handle direct suffix matches
-                const suffixMatch = ['run_command_background', 'run_do_file_background', 'get_ui_channel', 'break_session', 'stop_session', 'describe', 'codebook', 'get_data', 'get_variable_list', 'list_graphs', 'fetch_graph', 'export_all_graphs']
+                const suffixMatch = ['stata_run', 'stata_inspect_data', 'stata_manage_graphs', 'stata_read_log', 'stata_manage_session', 'stata_task_status', 'stata_control', 'stata_load_data', 'stata_inspect_results', 'stata_get_help']
                     .find(s => fullName.endsWith(s));
                 if (suffixMatch && !this._toolMapping.has(suffixMatch)) {
                     this._toolMapping.set(suffixMatch, fullName);
@@ -884,7 +884,7 @@ class StataMcpClient {
 
     async _callTool(client, name, args, callOptions = {}) {
         const toolName = name;
-        const resolvedName = this._resolveToolName(toolName);
+        let resolvedName = this._resolveToolName(toolName);
         if (resolvedName === 'read_log') {
             this._log('[mcp-stata] read_log tool call blocked: local file access only');
             throw new Error('read_log tool call disabled; local file access only');
@@ -898,6 +898,7 @@ class StataMcpClient {
                 if (!this._availableTools?.has(resolvedName)) {
                     await this._ensureLatestServerForMissingTool(toolName);
                     activeClient = await this._ensureClient();
+                    resolvedName = this._resolveToolName(toolName);
                     if (!this._availableTools?.has(resolvedName)) {
                         throw new Error(this._formatMissingToolError(toolName));
                     }
@@ -963,10 +964,9 @@ class StataMcpClient {
 
     _requiredToolNames() {
         return new Set([
-            'run_command_background',
-            'run_do_file_background',
-            'get_ui_channel',
-            'break_session'
+            'stata_run',
+            'stata_manage_session',
+            'stata_control'
         ]);
     }
 
@@ -1409,7 +1409,7 @@ class StataMcpClient {
     async _breakSession(client, sessionId = 'default') {
         if (!client) return;
         try {
-            await this._callTool(client, 'break_session', { session_id: sessionId });
+            await this._callTool(client, 'stata_control', { action: 'break', id: sessionId });
         } catch (err) {
             throw err;
         }
@@ -1497,23 +1497,15 @@ class StataMcpClient {
         const isMetadata = [
             'connect',
             'view_data',
-            'get_ui_channel',
-            'get_variable_list',
-            'get_data',
-            'describe',
-            'codebook',
-            'list_graphs',
-            'export_graph',
-            'export_all_graphs',
-            'export_graphs_all',
-            'get_task_status',
-            'get_task_result',
-            'get_help',
-            'get_stored_results',
-            'read_log',
-            'find_in_log',
-            'break_session',
-            'stop_session'
+            'stata_inspect_data',
+            'stata_manage_graphs',
+            'stata_read_log',
+            'stata_manage_session',
+            'stata_task_status',
+            'stata_control',
+            'stata_load_data',
+            'stata_inspect_results',
+            'stata_get_help'
         ].includes(label);
 
         if (!isMetadata && !config.get('enableExecuteTimeout', false)) {
@@ -2020,8 +2012,8 @@ class StataMcpClient {
         try {
             let response;
             let lastError = null;
-            response = await this._callTool(client, 'export_graphs_all', {});
-            this._log(`[mcp-stata graphs] export_graphs_all response: ${this._stringifySafe(response)}`);
+            response = await this._callTool(client, 'stata_manage_graphs', { action: 'export_all' });
+            this._log(`[mcp-stata graphs] export_all response: ${this._stringifySafe(response)}`);
 
             if (!response) {
                 if (lastError) throw lastError;
@@ -2152,10 +2144,10 @@ class StataMcpClient {
     async _exportGraphPreferred(client, name) {
         // Prefer PDF export for durable artifacts; fall back to default.
         try {
-            return await this._callTool(client, 'export_graph', { graph_name: name, format: 'pdf' });
+            return await this._callTool(client, 'stata_manage_graphs', { action: 'export', graph_name: name, format: 'pdf' });
         } catch (err) {
-            this._log(`[mcp-stata] export_graph (pdf) failed for "${name}", falling back to default format: ${err?.message || err}`);
-            return await this._callTool(client, 'export_graph', { graph_name: name });
+            this._log(`[mcp-stata] stata_manage_graphs (export:pdf) failed for "${name}", falling back to default format: ${err?.message || err}`);
+            return await this._callTool(client, 'stata_manage_graphs', { action: 'export', graph_name: name });
         }
     }
 

--- a/src/ui-shared/data-browser.js
+++ b/src/ui-shared/data-browser.js
@@ -505,7 +505,7 @@ async function loadPage() {
         perf.log('Data Fetch', fetchTime);
 
         if (data) {
-            const numRows = data.table ? data.table.numRows : (data.rows?.length || data.data?.length);
+            const numRows = data.table ? data.table.numRows : 0;
             log(`Page loaded. Records: ${numRows}`);
 
             perf.start('renderGrid');
@@ -601,7 +601,12 @@ function handleSort(varName, isMulti = false) {
 
 function renderGrid(pageData) {
     const varCount = pageData.vars?.length || pageData.variables?.length || 0;
-    log(`Render Grid. Vars: ${varCount}, Rows: ${pageData.rows?.length || pageData.data?.length}`);
+    const table = pageData.table;
+    const rows = [];
+    if (!table) {
+        throw new Error('Expected Arrow table in /v1/arrow response');
+    }
+    log(`Render Grid. Vars: ${varCount}, Rows: ${table.numRows}`);
     dom.header.innerHTML = '';
     const obsTh = document.createElement('th');
     obsTh.textContent = '#';
@@ -634,12 +639,10 @@ function renderGrid(pageData) {
     });
 
     dom.grid.innerHTML = '';
-    const table = pageData.table;
-    const rows = pageData.rows || pageData.data || [];
     const returnedVars = pageData.vars || pageData.variables || [];
     const obsIndex = returnedVars.indexOf('_n');
 
-    const numRows = table ? table.numRows : rows.length;
+    const numRows = table.numRows;
 
     for (let i = 0; i < numRows; i++) {
         const tr = document.createElement('tr');
@@ -647,12 +650,7 @@ function renderGrid(pageData) {
 
         let obsVal = '';
         if (obsIndex !== -1) {
-            if (table) {
-                // Direct Arrow Access
-                obsVal = table.getChildAt(obsIndex).get(i);
-            } else {
-                obsVal = rows[i][obsIndex];
-            }
+            obsVal = table.getChildAt(obsIndex).get(i);
         }
 
         tdObs.textContent = obsVal || '';
@@ -665,11 +663,7 @@ function renderGrid(pageData) {
             let val = null;
 
             if (idx !== -1) {
-                if (table) {
-                    val = table.getChildAt(idx).get(i);
-                } else {
-                    val = rows[i][idx];
-                }
+                val = table.getChildAt(idx).get(i);
             }
 
             td.textContent = (val === null || val === undefined) ? '.' : String(val);
@@ -690,8 +684,7 @@ function updatePagination(data) {
     if (!dom.prevBtn || !dom.nextBtn || !dom.pageInfo) return;
     dom.prevBtn.disabled = state.offset <= 0;
 
-    // Support both Arrow Table and legacy array
-    const returnedCount = data.table ? data.table.numRows : (data.rows || data.data || []).length;
+    const returnedCount = data.table ? data.table.numRows : 0;
 
     dom.nextBtn.disabled = returnedCount < state.limit;
     const start = state.offset + 1;

--- a/test/integration/suite/integration.test.js
+++ b/test/integration/suite/integration.test.js
@@ -96,7 +96,7 @@ describe('McpClient integration (VS Code host)', () => {
         const result = await client.runSelection('display "no-poll"', { normalizeResult: true, includeGraphs: false });
         expect(result.success).toBe(true);
         const combined = logLines.join('\n');
-        expect(combined).not.toContain('get_task_status');
+        expect(combined).not.toContain('stata_task_status');
         expect(combined).not.toContain('get_task_result');
     });
 

--- a/test/unit/mcp-auto-refresh.test.js
+++ b/test/unit/mcp-auto-refresh.test.js
@@ -49,9 +49,9 @@ describe('McpClient Auto-Refresh', () => {
         // Second client returns new tools
         secondClient.listTools.resolves({
             tools: [
-                { name: 'run_command_background' },
-                { name: 'run_do_file_background' },
-                { name: 'get_ui_channel' }
+                { name: 'stata_run' },
+                { name: 'stata_manage_session' },
+                { name: 'stata_control' }
             ]
         });
 
@@ -130,7 +130,7 @@ describe('McpClient Auto-Refresh', () => {
             await client.run('sysuse auto');
             throw new Error('Should have failed');
         } catch (err) {
-            expect(err.message.toLowerCase()).toContain('required tools: run_command_background');
+            expect(err.message.toLowerCase()).toContain('required tools: stata_run');
             expect(err.message).toContain('Available tools: run_command');
         }
     });

--- a/test/unit/mcp-break-session.test.js
+++ b/test/unit/mcp-break-session.test.js
@@ -22,7 +22,7 @@ describe("McpClient Break Session", () => {
         vscode.workspace.getConfiguration = () => ({
             get: (_key, def) => def
         });
-        client._availableTools = new Set(['run_command_background', 'break_session']);
+        client._availableTools = new Set(['stata_run', 'stata_manage_session', 'stata_control']);
         return client;
     };
 
@@ -45,7 +45,7 @@ describe("McpClient Break Session", () => {
         const mockClient = {
             type: 'standard',
             callTool: sinon.stub().callsFake(async ({ name }) => {
-                if (name.includes('run_command_background')) {
+                if (name.includes('stata_run')) {
                     return { task_id: 'task-long-running', log_path: '/tmp/stata.log' };
                 }
                 return {};
@@ -89,7 +89,7 @@ describe("McpClient Break Session", () => {
         expect(cancelled).toBe(true);
 
         // Verify break_session tool was called on the mock client
-        const breakCalls = mockClient.callTool.getCalls().filter(c => c.args[0].name.includes('break_session'));
+        const breakCalls = mockClient.callTool.getCalls().filter(c => c.args[0].name.includes('stata_control'));
         expect(breakCalls.length).toBeGreaterThan(0);
     });
 
@@ -102,15 +102,15 @@ describe("McpClient Break Session", () => {
         client._callTool = callToolStub;
 
         // Long running task details
-        callToolStub.withArgs(sinon.match.any, 'run_command_background', sinon.match({ code: sinon.match(/forvalues/) }))
+        callToolStub.withArgs(sinon.match.any, 'stata_run', sinon.match({ code: sinon.match(/forvalues/) }))
             .resolves({ task_id: 'task-1', log_path: '/tmp/1.log' });
 
         // Second task details
-        callToolStub.withArgs(sinon.match.any, 'run_command_background', sinon.match({ code: 'di "After Break"' }))
+        callToolStub.withArgs(sinon.match.any, 'stata_run', sinon.match({ code: 'di "After Break"' }))
             .resolves({ rc: 0, stdout: 'After Break\n' });
 
         // break_session takes some time
-        callToolStub.withArgs(sinon.match.any, 'break_session', sinon.match.any).callsFake(async () => {
+        callToolStub.withArgs(sinon.match.any, 'stata_control', sinon.match.any).callsFake(async () => {
             await new Promise(r => setTimeout(r, 10));
             return {};
         });

--- a/test/unit/mcp-client.test.js
+++ b/test/unit/mcp-client.test.js
@@ -323,7 +323,7 @@ describe('mcp-client', () => {
 
                 expect(enqueueSpy.calledOnce).toBe(true);
                 const args = enqueueSpy.firstCall.args;
-                expect(args[0]).toEqual('run_command');
+                expect(args[0]).toEqual('stata_run');
                 expect(args[5]).toEqual(true); // collectArtifacts flag
             });
         });
@@ -335,7 +335,8 @@ describe('mcp-client', () => {
 
                 const callToolStub = client._callTool;
                 callToolStub.callsFake(async (c, name, args) => {
-                    expect(name).toEqual('export_graph');
+                    expect(name).toEqual('stata_manage_graphs');
+                    expect(args.action).toEqual('export');
                     expect(args.graph_name).toEqual('g1');
                     expect(args.format).not.toBeDefined();
                     return { content: [{ type: 'text', text: '/tmp/g1.pdf' }] };
@@ -347,7 +348,7 @@ describe('mcp-client', () => {
                 expect(result).toBe(taskResult);
                 expect(enqueueSpy.calledOnce).toBe(true);
                 const [label, options] = enqueueSpy.firstCall.args;
-                expect(label).toEqual('fetch_graph');
+                expect(label).toEqual('stata_manage_graphs');
                 expect(options).toEqual({});
             });
         });
@@ -355,7 +356,7 @@ describe('mcp-client', () => {
         describe('getVariableList', () => {
             it('enqueues get_variable_list and returns normalized list', async () => {
                 const enqueueStub = sinon.stub(client, '_enqueue').callsFake(async (label, options, task) => {
-                    expect(label).toEqual('get_variable_list');
+                    expect(label).toEqual('stata_inspect_data');
                     expect(options).toEqual({});
                     const normalized = await task();
                     return normalized;
@@ -390,14 +391,14 @@ describe('mcp-client', () => {
         describe('getUiChannel', () => {
             it('enqueues get_ui_channel and returns parsed result', async () => {
                 const enqueueStub = sinon.stub(client, '_enqueue').callsFake(async (label, options, task) => {
-                    expect(label).toEqual('get_ui_channel');
+                    expect(label).toEqual('stata_manage_session');
                     expect(options).toEqual({});
                     const result = await task();
                     return result;
                 });
 
                 client._callTool.callsFake(async (c, name) => {
-                    expect(name).toEqual('get_ui_channel');
+                    expect(name).toEqual('stata_manage_session');
                     return { baseUrl: 'http://localhost:1234', token: 'xyz' };
                 });
 
@@ -428,7 +429,7 @@ describe('mcp-client', () => {
 
                 expect(enqueueStub.calledOnce).toBe(true);
                 const [label, rest, , meta, normalizeFlag, collectFlag] = enqueueStub.firstCall.args;
-                expect(label).toEqual('run_file');
+                expect(label).toEqual('stata_run');
                 expect('cancellationToken' in rest).toBeTruthy();
                 expect(normalizeFlag).toEqual(false);
                 expect(collectFlag).toEqual(false);
@@ -438,9 +439,10 @@ describe('mcp-client', () => {
                 expect(meta.filePath).toEqual('/tmp/project/script.do');
                 expect(meta.command).toEqual('do "/tmp/project/script.do"');
 
-                expect(result.taskResult.name).toEqual('run_do_file_background');
+                expect(result.taskResult.name).toEqual('stata_run');
                 expect(result.taskResult.args.cwd).toEqual(expectedCwd);
                 expect(result.taskResult.args.path).toEqual('/tmp/project/script.do');
+                expect(result.taskResult.args.is_file).toBe(true);
 
                 enqueueStub.restore();
                 setWorkspaceFolders(vscode, originalFolders);
@@ -480,11 +482,12 @@ describe('mcp-client', () => {
                 const result = await client.runSelection('display "hi"', { cwd: '/tmp/project', normalizeResult: false, includeGraphs: false });
 
                 expect(enqueueStub.calledOnce).toBe(true);
-                expect(result.label).toEqual('run_selection');
+                expect(result.label).toEqual('stata_run');
                 expect(result.meta.cwd).toEqual('/tmp/project');
-                expect(result.taskResult.name).toEqual('run_command_background');
+                expect(result.taskResult.name).toEqual('stata_run');
                 expect(result.taskResult.args.cwd).toEqual('/tmp/project');
                 expect(result.taskResult.args.code).toEqual('display "hi"');
+                expect(result.taskResult.args.background).toBe(true);
 
                 enqueueStub.restore();
             });
@@ -497,9 +500,9 @@ describe('mcp-client', () => {
                 const requestStub = sinon.stub().resolves({ ok: true });
                 const callToolStub = sinon.stub().resolves({});
                 const clientMock = { request: requestStub, callTool: callToolStub };
-                client._availableTools = new Set(['run_command']);
+                client._availableTools = new Set(['stata_run']);
 
-                await client._callTool(clientMock, 'run_command', { code: 'sleep 10' }, { progressToken: 'p_tok', signal: abort.signal });
+                await client._callTool(clientMock, 'stata_run', { code: 'sleep 10' }, { progressToken: 'p_tok', signal: abort.signal });
 
                 expect(requestStub.calledOnce).toBe(true);
                 const [reqPayload, , options] = requestStub.firstCall.args;
@@ -515,11 +518,11 @@ describe('mcp-client', () => {
                 const callToolStub = sinon.stub().rejects(abortErr);
                 const emitSpy = sinon.spy(client._statusEmitter, 'emit');
                 const clientMock = { callTool: callToolStub };
-                client._availableTools = new Set(['run_command']);
+                client._availableTools = new Set(['stata_run']);
 
                 let thrown = null;
                 try {
-                    await client._callTool(clientMock, 'run_command', { code: 'sleep 10' });
+                    await client._callTool(clientMock, 'stata_run', { code: 'sleep 10' });
                 } catch (err) {
                     thrown = err;
                 }
@@ -626,7 +629,7 @@ describe('mcp-client', () => {
 
                 // Stub _callTool for background kickoff, result, and read_log.
                 client._callTool = sinon.stub().callsFake(async (_client, name, args) => {
-                    if (name === 'run_command_background') {
+                    if (name === 'stata_run') {
                         return {
                             structuredContent: {
                                 result: JSON.stringify({
@@ -643,7 +646,7 @@ describe('mcp-client', () => {
                             content: [{ type: 'text', text: '' }]
                         };
                     }
-                    if (name === 'get_task_result') {
+                    if (name === 'stata_task_status') {
                         return {
                             structuredContent: {
                                 result: JSON.stringify({
@@ -659,7 +662,7 @@ describe('mcp-client', () => {
                             content: [{ type: 'text', text: '' }]
                         };
                     }
-                    if (name === 'read_log') {
+                    if (name === 'stata_read_log') {
                         // Return one chunk then empty.
                         const nextOffset = (args.offset || 0) === 0 ? 3 : 3;
                         const data = (args.offset || 0) === 0 ? 'abc\n' : '';
@@ -699,8 +702,9 @@ describe('mcp-client', () => {
                 client._delay = sinon.stub().resolves();
 
                 // run_command_background returns task_id but NO log_path (help early exit).
+                // stata_run returns task_id but NO log_path (help early exit).
                 client._callTool = sinon.stub().callsFake(async (_client, name) => {
-                    if (name === 'run_command_background') {
+                    if (name === 'stata_run') {
                         return {
                             content: [{ type: 'text', text: JSON.stringify({
                                 task_id: TASK_ID,
@@ -1117,12 +1121,12 @@ describe('mcp-client', () => {
         describe('listGraphs', () => {
             it('should resolve artifacts with client access', async () => {
                 // Mock list_graphs to return simple list of names
-                client._callTool.withArgs(sinon.match.any, 'list_graphs', sinon.match.any)
+                client._callTool.withArgs(sinon.match.any, 'stata_manage_graphs', sinon.match.has('action', 'list'))
                     .resolves({ graphs: ['g1'] });
 
                 // Mock export behavior for "g1"
                 client._exportGraphPreferred = sinon.stub().resolves({ content: [{ type: 'text', text: '/tmp/g1.pdf' }] });
-                client._callTool.withArgs(sinon.match.any, 'export_graph', sinon.match.has('format', 'png'))
+                client._callTool.withArgs(sinon.match.any, 'stata_manage_graphs', sinon.match.has('action', 'export'))
                     .resolves({ content: [{ type: 'text', text: '/tmp/g1.png' }] });
 
 
@@ -1148,12 +1152,12 @@ describe('mcp-client', () => {
                     ]
                 };
 
-                client._callTool.withArgs(sinon.match.any, 'list_graphs', sinon.match.any)
+                client._callTool.withArgs(sinon.match.any, 'stata_manage_graphs', sinon.match.has('action', 'list'))
                     .resolves(wrappedResponse);
 
                 // Mock export for both graphs
                 client._exportGraphPreferred = sinon.stub().callsFake(async (_c, name) => ({ content: [{ type: 'text', text: `/tmp/${name}.pdf` }] }));
-                client._callTool.withArgs(sinon.match.any, 'export_graph', sinon.match.has('format', 'png'))
+                client._callTool.withArgs(sinon.match.any, 'stata_manage_graphs', sinon.match.has('action', 'export'))
                     .callsFake(async (_c, _name, args) => ({ content: [{ type: 'text', text: `/tmp/${args.graph_name}.png` }] }));
 
                 const result = await client.listGraphs({ baseDir: '/tmp' });
@@ -1174,12 +1178,12 @@ describe('mcp-client', () => {
                     }]
                 };
 
-                client._callTool.withArgs(sinon.match.any, 'list_graphs', sinon.match.any)
+                client._callTool.withArgs(sinon.match.any, 'stata_manage_graphs', sinon.match.has('action', 'list'))
                     .resolves(wrappedResponse);
 
                 // Mock export
                 client._exportGraphPreferred = sinon.stub().resolves({ content: [{ type: 'text', text: '/tmp/g_wrapped.pdf' }] });
-                client._callTool.withArgs(sinon.match.any, 'export_graph', sinon.match.has('format', 'png'))
+                client._callTool.withArgs(sinon.match.any, 'stata_manage_graphs', sinon.match.has('action', 'export'))
                     .resolves({ content: [{ type: 'text', text: '/tmp/g_wrapped.png' }] });
 
 

--- a/test/unit/mcp-queue-cancel.test.js
+++ b/test/unit/mcp-queue-cancel.test.js
@@ -42,11 +42,11 @@ describe('McpClient Queue and Cancellation', () => {
         const client = new McpClient();
         client._log = () => {};
         client._ensureClient = sinon.stub().resolves(new ClientMock());
-        client._availableTools = new Set(['run_command_background', 'break_session']);
+        client._availableTools = new Set(['stata_run', 'stata_manage_session', 'stata_control']);
         
-        // Default mock for run_command_background
+        // Default mock for stata_run
         client._callTool = sinon.stub().callsFake(async (c, name, args) => {
-            if (name === 'run_command_background') {
+            if (name === 'stata_run') {
                 return {
                     task_id: 'task-' + Math.random(),
                     log_path: '/tmp/test.log'
@@ -158,7 +158,7 @@ describe('McpClient Queue and Cancellation', () => {
             const firstPromise = new Promise(r => resolveFirst = r);
             
             client._callTool = sinon.stub().callsFake(async (c, name) => {
-                if (name === 'run_command_background') {
+                if (name === 'stata_run') {
                     return { task_id: 'active-task' };
                 }
                 return {};

--- a/test/unit/mcp-queue-cancel.test.js
+++ b/test/unit/mcp-queue-cancel.test.js
@@ -217,43 +217,35 @@ describe('McpClient Queue and Cancellation', () => {
         });
     });
 
-    describe('Tool Name Mapping', () => {
-        itWithContext('should resolve tool names based on discovered mapping', async () => {
+    describe('Strict Tool Names', () => {
+        itWithContext('should keep tool names unchanged after discovery', async () => {
             const client = createClient();
-            // Mock listTools to return prefixed names
             const mockClient = new ClientMock();
             mockClient.listTools.resolves({
                 tools: [
-                    { name: 'mcp_stata_run_command_background' },
-                    { name: 'mcp_stata_break_session' }
+                    { name: 'stata_run' },
+                    { name: 'stata_control' }
                 ]
             });
             client._ensureClient = sinon.stub().resolves(mockClient);
 
-            // Connect to trigger tool discovery
-            await client._ensureClient(); // Usually called by _callTool but let's be explicit
+            await client._ensureClient();
             await client._refreshToolList(mockClient);
 
-            expect(client._resolveToolName('run_command_background')).toBe('mcp_stata_run_command_background');
-            expect(client._resolveToolName('break_session')).toBe('mcp_stata_break_session');
+            expect(client._resolveToolName('stata_run')).toBe('stata_run');
+            expect(client._resolveToolName('stata_control')).toBe('stata_control');
         });
 
-        itWithContext('should use resolved name in _callTool', async () => {
+        itWithContext('should fail when a requested tool is not available', async () => {
             const client = createClient();
-            // Restore real _callTool for this test
             client._callTool = McpClient.prototype._callTool.bind(client);
-            client._ensureClient = sinon.stub().resolves({ type: 'standard' });
-            
-            client._toolMapping = new Map([['break_session', 'prefixed_break']]);
-            client._availableTools = new Set(['prefixed_break']);
-            
+            client._ensureClient = sinon.stub().resolves({ type: 'standard', listTools: sinon.stub().resolves({ tools: [] }) });
+            client._availableTools = new Set(['stata_run']);
             const callToolStub = sinon.stub().resolves({});
             const mockClient = { callTool: callToolStub, type: 'standard' };
 
-            await client._callTool(mockClient, 'break_session', { session_id: 'default' });
-
-            expect(callToolStub.calledOnce).toBe(true);
-            expect(callToolStub.firstCall.args[0].name).toBe('prefixed_break');
+            await expect(client._callTool(mockClient, 'break_session', { session_id: 'default' })).rejects.toThrow(/not available/i);
+            expect(callToolStub.notCalled).toBe(true);
         });
     });
 


### PR DESCRIPTION
Replace legacy MCP tool names with a unified set of stata_* tool endpoints and update call semantics. Key changes:

- Replace usages of run_command*, run_do_file*, get_ui_channel, list_graphs, get_task_status, read_log, break_session, etc. with new endpoints such as stata_run, stata_inspect_data, stata_manage_graphs, stata_read_log, stata_manage_session, stata_task_status, stata_control, and others.
- Adjust arguments for file vs. code runs (add is_file, pass code or path accordingly, ensure background flag for background runs, normalize cwd handling).
- Update tool resolution and required tool list to expect the new stata_* names and refresh mapping logic when tools are missing.
- Update graph export flow to use stata_manage_graphs with action: 'export' / 'export_all' and prefer PDF exports via the new endpoint.
- Ensure read_log remains blocked for local-only access and re-resolve tool names after ensuring latest server tools.
- Update Sentry instrumentation filter to include stata_manage_session (and adjust localhost filtering logic).
- Update unit and integration tests to reflect renamed tool labels and revised argument expectations.

These changes migrate the client and tests to the new MCP tool naming and call contract so the extension talks to the consolidated server API.